### PR TITLE
docs: standardize README badges across all repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/devops-thiago/otel-example-go)](LICENSE)
 [![Codecov](https://img.shields.io/codecov/c/github/devops-thiago/otel-example-go?label=coverage)](https://app.codecov.io/gh/devops-thiago/otel-example-go)
 [![Sonar Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-go&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-go)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-go&metric=coverage)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-go)
+[![Sonar Coverage](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-go&metric=coverage)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-go)
 [![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-enabled-blue?logo=opentelemetry)](https://opentelemetry.io)
 [![Docker](https://img.shields.io/badge/Docker-ready-blue?logo=docker)](https://www.docker.com)
 [![Docker Hub](https://img.shields.io/docker/v/thiagosg/otel-crud-api-go?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/thiagosg/otel-crud-api-go)


### PR DESCRIPTION
- Align badge order: CI → language → framework → license → Codecov → Sonar Quality Gate → Sonar Coverage → OTel → Docker → Docker Hub → Docker Pulls
- Rename SonarCloud coverage badge label to 'Sonar Coverage' for clarity (was 'Coverage', clashing with Codecov)
- Use shields.io github/actions/workflow for CI badges (consistent style and avoids encoding issues)
- Use shields.io github/license for license badges (dynamic, no hardcoded spdx text)
- Use shields.io codecov for coverage badges (consistent style)

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link issues if applicable. -->

## Changes

<!-- Bullet list of what changed. Be specific: file names, before/after values. -->

-

## Test Plan

<!-- How was this verified? Check all that apply. -->

- [ ] Unit tests pass (`make test` / `npm run test:unit` / `dotnet test` / `poetry run pytest`)
- [ ] Linter / formatter clean (`make fmt-check` / `npm run lint` / `dotnet format --verify-no-changes`)
- [ ] Manual smoke test against local `docker compose up`
- [ ] Integration tests pass (if DB available)
- [ ] No new high-severity vulnerabilities (`npm audit --audit-level=high` / `trivy`)

## Checklist

- [ ] Commit messages follow Conventional Commits (`type(scope): description`)
- [ ] No debug output, commented-out code, or `TODO`s left behind
- [ ] Equivalent change applied to all relevant repos (if cross-repo feature)
- [ ] Docs / README updated if behaviour or setup changed
