### PR TITLE
chore: remove Trivy security scanner from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,19 +169,4 @@ jobs:
           echo "Checking if our image exists:"
           docker inspect otel-example-go:pr-${{ github.event.pull_request.number }}
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
-        with:
-          image-ref: otel-example-go:pr-${{ github.event.pull_request.number }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          skip-files: '/usr/share/zoneinfo/**'
-        env:
-          TRIVY_SKIP_VERSION_CHECK: true
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,19 +59,6 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       - name: Create SBOM
         uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
         with:


### PR DESCRIPTION
## Summary

- Removes \`aquasecurity/trivy-action\` from CI workflows due to the Trivy supply chain security incident
- Removes associated \`github/codeql-action/upload-sarif\` step (was only used to upload Trivy SARIF results)

## References

https://github.com/aquasecurity/trivy-action/issues/457

Made with [Cursor](https://cursor.com)