### PR TITLE
fix(security): add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege default token for all jobs (CodeQL: missing-workflow-permissions).
+# Jobs that need more (e.g. coverage publishing) declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the 5 open CodeQL `actions/missing-workflow-permissions` code-scanning alerts (ci.yml jobs at lines 15, 32, 75, 85, 98).

Adds a top-level least-privilege default:
```yaml
permissions:
  contents: read
```
All CI jobs now get a read-only `GITHUB_TOKEN` by default; the job that already declared its own `permissions:` block is unaffected (job-level overrides top-level).

The remaining single Trivy `low` alert is a base-image OS package and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)